### PR TITLE
explicitly set height of logo to fix Edge bug

### DIFF
--- a/public/styles/site/_layout.scss
+++ b/public/styles/site/_layout.scss
@@ -306,6 +306,7 @@ h2 {
 
     > .nav-logo > a > img {
       width: ($navbar-height * 2);
+      height: $navbar-height;
     }
   }
 }


### PR DESCRIPTION
When I was reading up on the speaker list for JSConf Uruguay, I stumbled onto a weird bug in Edge 

![image](https://cloud.githubusercontent.com/assets/465414/13000024/59ad5702-d10a-11e5-9745-9dc5addd0f34.png)

Note the logo in the header, it is really low compared to Chrome or Firefox

![image](https://cloud.githubusercontent.com/assets/465414/13000043/9953460a-d10a-11e5-8f58-a5a21bd0967f.png)

This is a bug in Edge. By the CSS 2.1 spec, an SVG image has a default size of 300x150px. You have a viewbox setup that changes this ratio, which goes onto create the intrinsic sizing based on the width that you already set. That should be overriding the default width and height from the spec. Currently, when you load an SVG image inside of an `<img>` tag, the intrinsic sizing is calculated incorrectly and the height of the logo is still 150px.
